### PR TITLE
Cache `SingleValidatorSign` circuit

### DIFF
--- a/prover/src/block_finality/mod.rs
+++ b/prover/src/block_finality/mod.rs
@@ -15,14 +15,11 @@ use crate::{
     ProofWithCircuitData,
 };
 
-mod indexed_validator_sign;
 pub mod validator_set_hash;
 mod validator_signs_chain;
 
 use validator_set_hash::ValidatorSetHash;
 use validator_signs_chain::ValidatorSignsChain;
-
-use self::validator_set_hash::ValidatorSetHashTarget;
 
 impl_target_set! {
     pub struct BlockFinalityTarget {

--- a/prover/src/block_finality/validator_signs_chain/single_validator_sign.rs
+++ b/prover/src/block_finality/validator_signs_chain/single_validator_sign.rs
@@ -1,0 +1,103 @@
+use plonky2::{
+    iop::witness::{PartialWitness, WitnessWrite},
+    plonk::{circuit_builder::CircuitBuilder, circuit_data::CircuitConfig},
+};
+
+use plonky2_ed25519::gadgets::eddsa::make_verify_circuits as ed25519_circuit;
+
+use super::GrandpaVoteTarget;
+use crate::{
+    common::{
+        array_to_bits,
+        targets::{impl_target_set, Ed25519PublicKeyTarget},
+        CircuitImplBuilder,
+    },
+    consts::GRANDPA_VOTE_LENGTH,
+    prelude::*,
+    ProofWithCircuitData,
+};
+
+use lazy_static::lazy_static;
+use plonky2::{iop::target::BoolTarget, plonk::circuit_data::CircuitData};
+
+use crate::common::CircuitDataCache;
+
+impl_target_set! {
+    pub struct PublicInputsTarget {
+        pub message: GrandpaVoteTarget,
+        pub public_key: Ed25519PublicKeyTarget,
+    }
+}
+
+pub struct SingleValidatorSign {
+    pub public_key: [u8; consts::ED25519_PUBLIC_KEY_SIZE],
+    pub signature: [u8; consts::ED25519_SIGNATURE_SIZE],
+    pub message: [u8; GRANDPA_VOTE_LENGTH],
+}
+
+impl SingleValidatorSign {
+    pub fn prove(self) -> ProofWithCircuitData<PublicInputsTarget> {
+        log::info!("        Proving single validator sign...");
+        let res = CACHE.prove(self);
+        log::info!("        Proven single validator sign...");
+        res
+    }
+}
+
+lazy_static! {
+    static ref CACHE: CircuitDataCache<SingleValidatorSign> = CircuitDataCache::new();
+}
+
+#[derive(Clone)]
+pub struct WitnessTargets {
+    public_key: [BoolTarget; consts::ED25519_PUBLIC_KEY_SIZE_IN_BITS],
+    signature: [BoolTarget; consts::ED25519_SIGNATURE_SIZE_IN_BITS],
+    message: [BoolTarget; GRANDPA_VOTE_LENGTH * 8],
+}
+
+impl CircuitImplBuilder for SingleValidatorSign {
+    type WitnessTargets = WitnessTargets;
+    type PublicInputsTarget = PublicInputsTarget;
+
+    fn build() -> (CircuitData<F, C, D>, Self::WitnessTargets) {
+        let mut builder = CircuitBuilder::<F, D>::new(CircuitConfig::wide_ecc_config());
+
+        // This fn registers public inputs as:
+        //  - message contents as `BoolTarget`s
+        //  - public key as `BoolTarget`s
+        let targets = ed25519_circuit(&mut builder, GRANDPA_VOTE_LENGTH);
+        let witness_targets = WitnessTargets {
+            public_key: targets
+                .pk
+                .try_into()
+                .expect("Incorrect amount of targets for targets.pk"),
+            signature: targets
+                .sig
+                .try_into()
+                .expect("Incorrect amount of targets for targets.sig"),
+            message: targets
+                .msg
+                .try_into()
+                .expect("Incorrect amount of targets for targets.msg"),
+        };
+
+        (builder.build(), witness_targets)
+    }
+
+    fn set_witness(&self, targets: Self::WitnessTargets, witness: &mut PartialWitness<F>) {
+        let pk_bits = array_to_bits(&self.public_key).into_iter();
+        for (target, value) in targets.public_key.iter().zip(pk_bits) {
+            witness.set_bool_target(*target, value);
+        }
+
+        let signature_bits = array_to_bits(&self.signature).into_iter();
+        for (target, value) in targets.signature.iter().zip(signature_bits) {
+            witness.set_bool_target(*target, value);
+        }
+
+        let msg_bits = array_to_bits(&self.message).into_iter();
+        for (target, value) in targets.message.iter().zip(msg_bits) {
+            witness.set_bool_target(*target, value);
+        }
+    }
+}

--- a/prover/src/common/generic_blake2.rs
+++ b/prover/src/common/generic_blake2.rs
@@ -14,12 +14,9 @@ use plonky2_blake2b256::circuit::{
     blake2_circuit_from_message_targets_and_length_target, BLOCK_BITS, BLOCK_BYTES,
 };
 use plonky2_field::types::Field;
-use std::iter;
 
 use crate::{
-    common::targets::{
-        impl_parsable_target_set, impl_target_set, ArrayTarget, Blake2Target, ByteTarget, TargetSet,
-    },
+    common::targets::{ArrayTarget, Blake2Target, ByteTarget, TargetSet},
     prelude::*,
     ProofWithCircuitData,
 };

--- a/prover/src/common/targets/byte.rs
+++ b/prover/src/common/targets/byte.rs
@@ -74,9 +74,9 @@ impl ByteTarget {
     /// Arranged from less to most significant bit.
     pub fn from_bit_targets(bits: [BoolTarget; 8], builder: &mut CircuitBuilder<F, D>) -> Self {
         let mut sum = builder.zero();
-        for bit_idx in 0..bits.len() {
+        for (bit_idx, bit_target) in bits.iter().enumerate() {
             let bit_value =
-                builder.mul_const(F::from_canonical_usize(1 << bit_idx), bits[bit_idx].target);
+                builder.mul_const(F::from_canonical_usize(1 << bit_idx), bit_target.target);
             sum = builder.add(sum, bit_value);
         }
         Self(sum)

--- a/prover/src/latest_validator_set/mod.rs
+++ b/prover/src/latest_validator_set/mod.rs
@@ -116,7 +116,7 @@ impl Circuit {
             ),
         );
 
-        ProofWithCircuitData::from_circuit_data(self.cyclic_circuit_data, self.witness)
+        ProofWithCircuitData::from_circuit_data(&self.cyclic_circuit_data, self.witness)
     }
 
     pub fn prove_recursive(
@@ -127,7 +127,7 @@ impl Circuit {
         self.witness
             .set_proof_with_pis_target(&self.inner_cyclic_proof_with_pis, &composed_proof);
 
-        ProofWithCircuitData::from_circuit_data(self.cyclic_circuit_data, self.witness)
+        ProofWithCircuitData::from_circuit_data(&self.cyclic_circuit_data, self.witness)
     }
 }
 

--- a/prover/src/lib.rs
+++ b/prover/src/lib.rs
@@ -1,5 +1,4 @@
 #![allow(incomplete_features)]
-#![feature(return_position_impl_trait_in_trait)]
 
 use jemallocator::Jemalloc;
 
@@ -22,12 +21,10 @@ pub mod prelude {
     pub type C = PoseidonGoldilocksConfig;
     pub const D: usize = 2;
 
-    pub(crate) use super::consts;
-
-    pub use super::consts::GENESIS_AUTHORITY_SET_ID;
+    pub use super::consts;
 }
 
-pub(crate) mod consts {
+pub mod consts {
     pub const CIRCUIT_DIGEST_SIZE: usize = 4;
 
     // For now we send a single Keccak256 hash.

--- a/prover/src/storage_inclusion/storage_trie_proof/branch_node_chain.rs
+++ b/prover/src/storage_inclusion/storage_trie_proof/branch_node_chain.rs
@@ -155,7 +155,7 @@ impl Circuit {
         );
 
         let result =
-            ProofWithCircuitData::from_circuit_data(self.cyclic_circuit_data, self.witness);
+            ProofWithCircuitData::from_circuit_data(&self.cyclic_circuit_data, self.witness);
 
         log::info!("    Proven storage trie recursion layer(initial)...");
 
@@ -172,7 +172,7 @@ impl Circuit {
             .set_proof_with_pis_target(&self.inner_cyclic_proof_with_pis, &composed_proof);
 
         let result =
-            ProofWithCircuitData::from_circuit_data(self.cyclic_circuit_data, self.witness);
+            ProofWithCircuitData::from_circuit_data(&self.cyclic_circuit_data, self.witness);
 
         log::info!("    Proven storage trie recursion layer");
 

--- a/prover/src/storage_inclusion/storage_trie_proof/node_parser/branch_parser/child_node_array_parser/mod.rs
+++ b/prover/src/storage_inclusion/storage_trie_proof/node_parser/branch_parser/child_node_array_parser/mod.rs
@@ -184,7 +184,7 @@ impl Circuit {
         );
 
         let result =
-            ProofWithCircuitData::from_circuit_data(self.cyclic_circuit_data, self.witness);
+            ProofWithCircuitData::from_circuit_data(&self.cyclic_circuit_data, self.witness);
 
         log::info!("    Proven child node parser recursion layer(initial)...");
 
@@ -201,7 +201,7 @@ impl Circuit {
             .set_proof_with_pis_target(&self.inner_cyclic_proof_with_pis, &composed_proof);
 
         let result =
-            ProofWithCircuitData::from_circuit_data(self.cyclic_circuit_data, self.witness);
+            ProofWithCircuitData::from_circuit_data(&self.cyclic_circuit_data, self.witness);
 
         log::info!("    Proven child node parser recursion layer");
 

--- a/relayer/src/main.rs
+++ b/relayer/src/main.rs
@@ -13,7 +13,7 @@ use prover::{
     latest_validator_set::{
         next_validator_set::NextValidatorSet, LatestValidatorSet, LatestValidatorSetTarget,
     },
-    prelude::GENESIS_AUTHORITY_SET_ID,
+    prelude::consts::GENESIS_AUTHORITY_SET_ID,
     storage_inclusion::{BranchNodeData, StorageInclusion},
 };
 


### PR DESCRIPTION
Circuit build time relates to proving time as ~ 2/3. So caching circuit for `ed25519` will allow to decrease overall proving time by 30-40% on mainnet as validator sign proofs take ~90% of overall proving time